### PR TITLE
Fixes #5 – Badge Icons Overlap with Circular Containers

### DIFF
--- a/drawCard.js
+++ b/drawCard.js
@@ -554,7 +554,9 @@ async function renderBadgesSVG(badges, displayBadges) {
             <g class="achievement" style="animation-delay: 450ms" transform="translate(25, 0)">
                 <svg viewBox="0 0 24 24" width="24" height="24" overflow="visible" class="${iconClass}">
                     <circle cx="12" cy="12" r="50%" />
-                    ${fs.readFileSync(iconPath, { encoding: 'utf8', flag: 'r' })}
+                    <g transform="scale(0.65)" style="transform-origin: center;">
+                        ${fs.readFileSync(iconPath, { encoding: 'utf8', flag: 'r' })}
+                    </g>
                 </svg>
                 <text class="label  bold" x="35" y="17">${badgeName}</text>
             </g>


### PR DESCRIPTION
#### Problem
Badge icons in the WordPress profile cards were too large for their circular containers, causing visual overlap and alignment issues. This affected the overall appearance and readability of the contributor badges.

#### Solution
This PR improves the badge display by:
- Reducing the icon size to 65% of original size
- Setting the transform-origin to center for proper scaling
- Maintaining the existing circle sizes and colors

#### Changes
- Modified the SVG transformation in `drawCard.js` to scale icons appropriately
- Used a simpler, more maintainable approach with `transform-origin: center`
- Preserved all badge colors and circle styling

#### Testing
Tested with multiple profile cards with various badge combinations to ensure proper display.


#### Related Issue
Fixes #5 - Badge Icons Overflow Circular Containers

**Visual Reference:**
| Before | After |
|--------|-------|
| ![Badge Overflow](https://github.com/user-attachments/assets/94f8dd07-00a2-4c8c-a629-a5b301c1d33b) | ![After Fix](https://github.com/user-attachments/assets/e910e830-bb2a-49ad-a2f4-7aa834b11604) |

