### PR TITLE
Add header toggle functionality

### DIFF
--- a/drawCard.js
+++ b/drawCard.js
@@ -10,9 +10,10 @@ const http = require('https');
  * @param {Avatar code in 64} avatar64 
  * @param {Formatted badges list} badges 
  * @param {Dynamic height value for the card based on content} dynHeight 
+ * @param {Display header section} displayHeader 
  * @returns SVG code with the user profile card
  */
-function renderCard(username, name, initials, membersince, avatar64, badges, dynHeight) {
+function renderCard(username, name, initials, membersince, avatar64, badges, dynHeight, displayHeader) {
 
 	let htmlResult =  `
 <svg width="500" height="${dynHeight}" viewBox="0 0 500 ${dynHeight}" fill="none" xmlns="http://www.w3.org/2000/svg" overflow="visible">
@@ -503,7 +504,7 @@ function renderCard(username, name, initials, membersince, avatar64, badges, dyn
 ]]>
 </style>
   <rect x="0" y="0" rx="4.5" height="99%" stroke="#e4e2e2" width="99%" fill="#ffffff" stroke-opacity="1" />
-    <g xmlns="http://www.w3.org/2000/svg" class="card-title" transform="translate(25, 35)">
+    ${('true' === displayHeader) ? `<g xmlns="http://www.w3.org/2000/svg" class="card-title" transform="translate(25, 35)">
         <g transform="translate(0, -15)">
 			<svg width="100" height="100">
 				<circle cx="50" cy="50" r="50%" stroke="#e4e2e2" fill="#ffffff" stroke-opacity="1" />
@@ -519,8 +520,8 @@ function renderCard(username, name, initials, membersince, avatar64, badges, dyn
 				<tspan x="0" y="65" class="subheader">Member Since: ${membersince}</tspan>
 			</text>
         </g>
-    </g>
-    <g class="badges" transform="translate(0, 140)">
+    </g>` : ''}
+    <g class="badges" transform="translate(0, ${('true' === displayHeader) ? '140' : '25'})">
         <svg viewBox="0 0 430 400" width="430" height="400" overflow="visible" class="row">
             ${badges}
         </svg>

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ If you want to use your card in a markdown file, just copy & paste the code belo
 
 #### Options
 - **badges** [true|false] default true: Show / Hide profile badges
+- **header** [true|false] default true: Show / Hide header section (avatar, name, username, member since)
 - **refresh** [true|false] default false: Refresh profile card content
 
 ### TODO LIST

--- a/routes/index.js
+++ b/routes/index.js
@@ -16,12 +16,14 @@ const axios = require('axios');
  *  color: string HEX color
  *  foreground: string HEX color
  *  badges: boolean
+ *  header: boolean
  *  avatar: boolean
  * }
  */
 router.get('/card', async (req, res, next) => {
   let username      = req.query.username;
   let displayBadges = (undefined === req.query.badges) ? 'true' : req.query.badges;
+  let displayHeader = (undefined === req.query.header) ? 'true' : req.query.header;
   let refresh       = (undefined === req.query.refresh) ? 'false' : req.query.refresh;
   let color         = (undefined === req.query.color) ? '000000' : req.query.color; // TODO
   let foreground    = (undefined === req.query.foreground) ? 'ffffff' : req.query.foreground; // TODO
@@ -43,7 +45,7 @@ router.get('/card', async (req, res, next) => {
 
     const badges        = await draw.renderBadgesSVG(userData["badges"], displayBadges);
     const badgesCount   = userData["badges"].length;
-    const defaultHeight = 145;
+    const defaultHeight = ('true' === displayHeader) ? 145 : 50; // Reduced height when header is hidden
     const dynHeight     = ('true' === displayBadges) ? (defaultHeight + (32 * Math.floor((badgesCount > 4) ? badgesCount / 2 : badgesCount)) + ((badgesCount % 2 === 0) ? 0 : 30)) : defaultHeight;
 
 
@@ -67,7 +69,7 @@ router.get('/card', async (req, res, next) => {
         const contentType = response.headers['content-type'];
         const base64Image = `data:${contentType};base64,${base64}`;
 
-        let htmlResult = await draw.renderCard(username, name, initials, membersince, base64Image, badges, dynHeight);
+        let htmlResult = await draw.renderCard(username, name, initials, membersince, base64Image, badges, dynHeight, displayHeader);
 
         fs.writeFileSync(avatarPath + username + '/card.svg', htmlResult);
         console.log('✅ SVG created with embedded image.');


### PR DESCRIPTION
This PR introduces a new `header` parameter to control the visibility of the header section in profile cards.

## Changes

* Added `header` parameter to the `renderCard` function
* Implemented conditional rendering of the header section based on the `header` value
* Adjusted badge positioning when the header is hidden
* Updated JSDoc to include documentation for the new parameter

## Testing

You can test the behavior locally by passing the `header` parameter in the URL:

* **Header hidden:**
  `http://localhost:3000/card?username=huzaifaalmesbah&header=false&refresh=true`

* **Header visible:**
  `http://localhost:3000/card?username=huzaifaalmesbah&header=true&refresh=true`

### Expected Results:

* When `header=true`, the card displays the header section with avatar and user details
* When `header=false` (or omitted), only the badges section is shown
* Badge layout remains consistent in both cases

## Screenshots

![Huzaifa-20250531122347](https://github.com/user-attachments/assets/ca414bb1-e5f3-4e71-b0c9-6233aaffecad)

## Closes

Closes #7