### PR TITLE
Enable CORS pre-flight

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -16,6 +16,8 @@ const axios = require('axios');
 const avatarPath    = "public/images/avatar/";
 const directoryPath = path.join(__dirname, '../'.concat(avatarPath));
 
+router.options('*', cors());
+
 /**
  * Generate card
  * Params: {


### PR DESCRIPTION
@donini, while testing the new JSON endpoint inside a WordPress block, using apiFetch to fetch the JSON data, I'm still seeing a CORS error in the console

![profile-card-block](https://github.com/user-attachments/assets/bd13704f-58b6-4a46-9963-865b7a605263)

I will admit that I don't know much express.js or the express router, but after some digging, it looks like we need to add this line to enable CORS pre-flight ([source](https://stackoverflow.com/questions/44736327/node-js-cors-issue-response-to-preflight-request-doesnt-pass-access-control-c))

Please check and see if you agree with this, or let me know if there's a better way. I'm mostly guessing here based on what I'm finding on the internet.



